### PR TITLE
Distributor AddQuest permissions

### DIFF
--- a/contracts/MultiMerkleDistributor.sol
+++ b/contracts/MultiMerkleDistributor.sol
@@ -237,7 +237,8 @@ contract MultiMerkleDistributor is Ownable {
     * @param token Address of the ERC20 reward token
     * @return bool : success
     */
-    function addQuest(uint256 questID, address token) external onlyAllowed returns(bool) {
+    function addQuest(uint256 questID, address token) external returns(bool) {
+        require(msg.sender == questBoard, "MultiMerkle: Not allowed");
         require(questRewardToken[questID] == address(0), "MultiMerkle: Quest already listed");
         require(token != address(0), "MultiMerkle: Incorrect reward token");
 

--- a/test/multiMerkle.test.ts
+++ b/test/multiMerkle.test.ts
@@ -139,7 +139,11 @@ describe('MultiMerkleDistributor contract tests', () => {
 
         });
 
-        it(' should only be callable by allowed managers', async () => {
+        it(' should only be callable by the QuestBoard', async () => {
+
+            await expect(
+                distributor.connect(admin).addQuest(quest_id1, CRV.address)
+            ).to.be.revertedWith('MultiMerkle: Not allowed')
 
             await expect(
                 distributor.connect(user1).addQuest(quest_id1, CRV.address)


### PR DESCRIPTION
Change permission on Distributor addQuest to allow only the QuestBoard to call the method.
+ update test